### PR TITLE
Remove typo in documentated example for CollectionOf DSL

### DIFF
--- a/dsl/result_type.go
+++ b/dsl/result_type.go
@@ -281,12 +281,12 @@ func View(name string, adsl ...func()) {
 //	        Example("DivisionResult Collection Examples", func() {
 //	            Value([]Val{
 //	                {
-//	                    "value":    4.167,
-//	                    "reminder": 0,
+//	                    "value":     4.167,
+//	                    "remainder": 0,
 //	                },
 //	                {
-//	                    "value":    3.0,
-//	                    "reminder": 0,
+//	                    "value":     3.0,
+//	                    "remainder": 0,
 //	                },
 //	            })
 //	        })


### PR DESCRIPTION
The documentation for the `CollectionOf` DSL contains a typo of "reminder" when it should be "remainder".

This is used in context of the division/calc example.  If you were to use this documentation example without modification, it would provide example data that does not function with its expected view.